### PR TITLE
chore: Lower guzzle dependency version restriction (>= 5.3)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": ">= 5.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.4",


### PR DESCRIPTION
Allowing the consumers of the package to use Guzzle 5.3 and above, for easier integration on their end when the dependencies are more restricted